### PR TITLE
Fixes #5 - unable to compile with go1.6

### DIFF
--- a/cpuidlow_amd64.s
+++ b/cpuidlow_amd64.s
@@ -1,3 +1,5 @@
+#include "textflag.h"
+
 // func cpuid_low(arg1, arg2 uint32) (eax, ebx, ecx, edx uint32)
 TEXT ·cpuid_low(SB),NOSPLIT,$0-24
     MOVL    arg1+0(FP), AX


### PR DESCRIPTION
Includes textflag header to fix.