### PR TITLE
Parse Processor Brand and Thermal/Power leaves, plus misc changes

### DIFF
--- a/cpuid.go
+++ b/cpuid.go
@@ -12,6 +12,9 @@ package cpuid
 // VendorIndentificationString like "GenuineIntel" or "AuthenticAMD"
 var VendorIdentificatorString string
 
+// ProcessorBrandString like "Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz"
+var ProcessorBrandString string
+
 // SteppingId is Processor Stepping ID as described in
 // Intel® 64 and IA-32 Architectures Software Developer’s Manual
 var SteppingId uint32
@@ -340,6 +343,7 @@ func detectFeatures() {
 	leaf7()
 	leaf0x80000000()
 	leaf0x80000001()
+	leaf0x80000004()
 	leaf0x80000005()
 	leaf0x80000006()
 
@@ -742,21 +746,19 @@ func leaf0x80000001() {
 	extraFeatureFlags = (uint64(edx) << 32) | uint64(ecx)
 }
 
-func leaf0x80000002() {
-	// Processor Brand String
-}
-
-func leaf0x80000003() {
-	// Processor Brand String continued
-}
-
+// leaf0x80000004 looks at the Processor Brand String in leaves 0x80000002 through 0x80000004
 func leaf0x80000004() {
-	// Processor Brand String continued
+	if maxExtendedInputValue < 0x80000004 {
+		return
+	}
+
+	ProcessorBrandString += string(int32sToBytes(cpuid_low(0x80000002, 0)))
+	ProcessorBrandString += string(int32sToBytes(cpuid_low(0x80000003, 0)))
+	ProcessorBrandString += string(int32sToBytes(cpuid_low(0x80000004, 0)))
 }
 
 func leaf0x80000005() {
 	// AMD L1 Cache and TLB Information
-
 	if maxExtendedInputValue < 0x80000005 {
 		return
 	}

--- a/cpuid.go
+++ b/cpuid.go
@@ -533,6 +533,7 @@ const (
 
 // Thermal and Power Management features
 const (
+	// EAX bits 0-15
 	TEMPERATURE_SENSOR        = uint32(1) << iota // Digital temperature sensor
 	TURBO_BOOST                                   // Intel Turbo Boost Technology available
 	ARAT                                          // APIC-Timer-always-running feature is supported if set.
@@ -545,10 +546,13 @@ const (
 	HWP_ACTIVITY_WINDOW                           // IA32_HWP_REQUEST[bits 41:32]
 	HWP_ENERGY_PERFORMANCE                        // IA32_HWP_REQUEST[bits 31:24]
 	HWP_PACKAGE_LEVEL_REQUEST                     // IA32_HWP_REQUEST_PKG MSR
-	_                                             // Reserved
+	_                                             // Reserved (eax bit 12)
 	HDC                                           // HDC base registers IA32_PKG_HDC_CTL, IA32_PM_CTL1, IA32_THREAD_STALL MSRs
 	TURBO_BOOST_MAX                               // Intel® Turbo Boost Max Technology
-	HCFC                                          // Hardware Coordination Feedback Capability
+	_                                             // Reserved (eax bit 15)
+
+	// ECX bits 0-15
+	HCFC // Hardware Coordination Feedback Capability
 	_
 	_
 	PERFORMANCE_ENERGY_BIAS // Processor supports performance-energy bias preference
@@ -724,7 +728,7 @@ func leaf6() {
 	}
 
 	eax, ebx, ecx, _ := cpuid_low(6, 0)
-	thermalAndPowerFeatureFlags = eax | (ecx << 15)
+	thermalAndPowerFeatureFlags = (eax & 0xFFFF) | (ecx << 16)
 	ThermalSensorInterruptThresholds = ebx & 7
 }
 

--- a/example/example.go
+++ b/example/example.go
@@ -20,11 +20,12 @@ func main() {
 	fmt.Printf("MaxLogocalCPUId:%d\n", cpuid.MaxLogocalCPUId)
 	fmt.Printf("InitialAPICId:  %d\n", cpuid.InitialAPICId)
 	fmt.Printf("Smallest monitor-line size in bytes:  %d\n", cpuid.MonLineSizeMin)
-	fmt.Printf("Largest monitor-line size in bytes:  %d\n", cpuid.MonLineSizeMax)
+	fmt.Printf("Largest monitor-line size in bytes:   %d\n", cpuid.MonLineSizeMax)
 	fmt.Printf("Monitor Interrupt break-event is supported:  %v\n", cpuid.MonitorIBE)
-	fmt.Printf("MONITOR/MWAIT extensions are supported:  %v\n", cpuid.MonitorEMX)
-	fmt.Printf("AVX state %v\n", cpuid.EnabledAVX)
-	fmt.Printf("AVX-512 state %v\n", cpuid.EnabledAVX512)
+	fmt.Printf("MONITOR/MWAIT extensions are supported:      %v\n", cpuid.MonitorEMX)
+	fmt.Printf("AVX state:     %v\n", cpuid.EnabledAVX)
+	fmt.Printf("AVX-512 state: %v\n", cpuid.EnabledAVX512)
+	fmt.Printf("Interrupt thresholds in digital thermal sensor: %v\n", cpuid.ThermalSensorInterruptThresholds)
 
 	fmt.Printf("Features: ")
 	for i := uint64(0); i < 64; i++ {

--- a/example/example.go
+++ b/example/example.go
@@ -5,12 +5,13 @@
 package main
 
 import (
-	"github.com/intel-go/cpuid"
 	"fmt"
+	"github.com/intel-go/cpuid"
 )
 
 func main() {
-	fmt.Printf("VendorString:   %s\n", cpuid.VendorIdentificatorString)
+	fmt.Printf("VendorString:           %s\n", cpuid.VendorIdentificatorString)
+	fmt.Printf("ProcessorBrandString:   %s\n", cpuid.ProcessorBrandString)
 	fmt.Printf("SteppingId:     %d\n", cpuid.SteppingId)
 	fmt.Printf("ProcessorType:  %d\n", cpuid.ProcessorType)
 	fmt.Printf("DisplayFamily:  %d\n", cpuid.DisplayFamily)

--- a/example/example.go
+++ b/example/example.go
@@ -49,6 +49,16 @@ func main() {
 	}
 	fmt.Printf("\n")
 
+	fmt.Printf("ThermalAndPowerFeatures: ")
+	for i := uint32(0); i < 64; i++ {
+		if cpuid.HasThermalAndPowerFeature(1 << i) {
+			if name, found := cpuid.ThermalAndPowerFeatureNames[1<<i]; found {
+				fmt.Printf("%s ", name)
+			}
+		}
+	}
+	fmt.Printf("\n")
+
 	for _, cacheDescription := range cpuid.CacheDescriptors {
 		fmt.Printf("CacheDescriptor: %v\n", cacheDescription)
 	}


### PR DESCRIPTION
Specifically:
1) Add support for parsing the Thermal and Power Features leaf.
2) Added support for parsing the Processor Brand String from leaves 0x80000002 through 0x80000004.
3) Minor formatting changes to the example, plus print the result of the ThermalSensorInterruptThresholds value.
4) Changed int32ToBytes to accept a list of ints. This make it more convenient to use in a few places.
5) Changed the brandId to be a simple int, instead of a function. The result of the function never changes, and seemed unnecessary.

If you'd prefer to review these separately, I can send multiple pull requests. Thanks.
