### PR TITLE
Typo in comment for vendor identification string

### DIFF
--- a/cpuid.go
+++ b/cpuid.go
@@ -9,7 +9,7 @@
 
 package cpuid
 
-// VendorIndentificationString like "GenuineIntel" or "AuthenticAMD"
+// VendorIdentificationString like "GenuineIntel" or "AuthenticAMD"
 var VendorIdentificatorString string
 
 // ProcessorBrandString like "Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz"


### PR DESCRIPTION
This makes a slight correction to the Vendor Identification String comment but does not correct the more critical misspelling of VendorIdentificationString variable itself.