### PR TITLE
add AVX512VBMI2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ if EnabledAVX && HasFeature(AVX) {
   > **AVX512VL**                AVX-512 Vector Length Extensions<br/>
   > **PREFETCHWT1**             PREFETCHWT1 instruction<br/>
   > **AVX512VBMI**              AVX-512 Vector Bit Manipulation Instructions<br/>
+  > **AVX512VBMI2**             AVX-512 Vector Bit Manipulation Instructions, Version 2<br/>
 
 * **func HasExtraFeature(feature uint64) bool**
   > **LAHF_LM**           LahfSahf LAHF and SAHF instruction support in 64-bit mod<br/>

--- a/cpuid.go
+++ b/cpuid.go
@@ -113,12 +113,6 @@ func HasThermalAndPowerFeature(feature uint32) bool {
 	return (thermalAndPowerFeatureFlags & feature) != 0
 }
 
-// CanEnableCryptoMB to check if CryptoMB can be enabled on the current processor
-func CanEnableCryptoMB() bool {
-	// reference: https://github.com/intel/ipp-crypto/blob/46944bd18e6dbad491ef9b9a3404303ef7680c09/sources/ippcp/crypto_mb/src/common/cpu_features.c#L227
-	return HasExtendedFeature(BMI2) && HasExtendedFeature(AVX512F) && HasExtendedFeature(AVX512DQ) && HasExtendedFeature(AVX512BW) && HasExtendedFeature(AVX512IFMA) && HasExtendedFeature(AVX512VBMI2) && EnabledAVX512
-}
-
 var FeatureNames = map[uint64]string{
 	SSE3:         "SSE3",
 	PCLMULQDQ:    "PCLMULQDQ",

--- a/cpuid.go
+++ b/cpuid.go
@@ -113,6 +113,12 @@ func HasThermalAndPowerFeature(feature uint32) bool {
 	return (thermalAndPowerFeatureFlags & feature) != 0
 }
 
+// CanEnableCryptoMB to check if CryptoMB can be enabled on the current processor
+func CanEnableCryptoMB() bool {
+	// reference: https://github.com/intel/ipp-crypto/blob/46944bd18e6dbad491ef9b9a3404303ef7680c09/sources/ippcp/crypto_mb/src/common/cpu_features.c#L227
+	return HasExtendedFeature(BMI2) && HasExtendedFeature(AVX512F) && HasExtendedFeature(AVX512DQ) && HasExtendedFeature(AVX512BW) && HasExtendedFeature(AVX512IFMA) && HasExtendedFeature(AVX512VBMI2) && EnabledAVX512
+}
+
 var FeatureNames = map[uint64]string{
 	SSE3:         "SSE3",
 	PCLMULQDQ:    "PCLMULQDQ",
@@ -228,6 +234,7 @@ var ExtendedFeatureNames = map[uint64]string{ // From leaf07
 	AVX512VL:              "AVX512VL",
 	PREFETCHWT1:           "PREFETCHWT1",
 	AVX512VBMI:            "AVX512VBMI",
+	AVX512VBMI2:           "AVX512VBMI2",
 }
 
 var ExtraFeatureNames = map[uint64]string{ // From leaf 8000 0001
@@ -450,6 +457,11 @@ const (
 	// ECX's const from there
 	PREFETCHWT1
 	AVX512VBMI
+	_
+	_
+	_
+	_
+	AVX512VBMI2
 )
 
 const (


### PR DESCRIPTION
add extended feature `AVX512VBMI2` , reference from https://github.com/intel/ipp-crypto/blob/46944bd18e6dbad491ef9b9a3404303ef7680c09/sources/ippcp/crypto_mb/src/common/cpu_features.c#L156
